### PR TITLE
Add connect framework

### DIFF
--- a/benchmarks/connect-router.js
+++ b/benchmarks/connect-router.js
@@ -1,0 +1,14 @@
+'use strict'
+
+var connect = require('connect')
+var router = require('router')()
+var app = connect()
+
+router.get('/', function (req, res) {
+  res.end(JSON.stringify({ hello: 'world' }))
+})
+
+app
+  .use(router)
+
+app.listen(3000)

--- a/benchmarks/connect.js
+++ b/benchmarks/connect.js
@@ -1,0 +1,10 @@
+'use strict'
+
+var connect = require('connect')
+var app = connect()
+
+app.use(function (req, res) {
+  res.end(JSON.stringify({ hello: 'world' }))
+})
+
+app.listen(3000)

--- a/index.js
+++ b/index.js
@@ -3,7 +3,20 @@ const { exec, fork } = require('child_process')
 const ora = require('ora')
 const globalModules = require('global-modules')
 
-let list = ['bare', 'express-route-prefix', 'express-with-middlewares', 'express', 'hapi', 'koa-router', 'koa', 'restify', 'take-five', 'fastify']
+let list = [
+  'bare',
+  'connect',
+  'connect-router',
+  'express-route-prefix',
+  'express-with-middlewares',
+  'express',
+  'hapi',
+  'koa-router',
+  'koa',
+  'restify',
+  'take-five',
+  'fastify'
+]
 
 const doBench = handler => {
   return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "autocannon": "^0.16.5",
+    "connect": "^3.6.3",
     "cors": "^2.8.4",
     "dns-prefetch-control": "^0.1.0",
     "express": "^4.15.4",
@@ -26,6 +27,7 @@
     "koa": "^2.3.0",
     "koa-router": "^7.2.1",
     "restify": "^5.2.0",
+    "router": "^1.3.1",
     "take-five": "^1.3.4",
     "x-xss-protection": "^1.0.0"
   },


### PR DESCRIPTION
I hope it's OK, but figured I'd add the `connect` framework to the list here. 7.4k stars on GitHub and it's the low overhead version of Express.js for the most part. Users who don't need the Express.js sugar simply use `connect` (and + the `rotuer` if they want router -- can use other routers too, but most use the Express-like one).