### PR TITLE
Update examples to make all server responses the same

### DIFF
--- a/benchmarks/bare.js
+++ b/benchmarks/bare.js
@@ -5,5 +5,6 @@ var server = require('http').createServer(handle)
 server.listen(3000)
 
 function handle (req, res) {
+  res.setHeader('Content-Type', 'application/json')
   res.end(JSON.stringify({ hello: 'world' }))
 }

--- a/benchmarks/connect-router.js
+++ b/benchmarks/connect-router.js
@@ -5,6 +5,7 @@ var router = require('router')()
 var app = connect()
 
 router.get('/', function (req, res) {
+  res.setHeader('Content-Type', 'application/json')
   res.end(JSON.stringify({ hello: 'world' }))
 })
 

--- a/benchmarks/connect.js
+++ b/benchmarks/connect.js
@@ -4,6 +4,7 @@ var connect = require('connect')
 var app = connect()
 
 app.use(function (req, res) {
+  res.setHeader('Content-Type', 'application/json')
   res.end(JSON.stringify({ hello: 'world' }))
 })
 

--- a/benchmarks/express-route-prefix.js
+++ b/benchmarks/express-route-prefix.js
@@ -3,10 +3,13 @@
 const express = require('express')
 const app = express()
 
+app.disable('etag')
+app.disable('x-powered-by')
+
 const router = express.Router()
 
 router.get('/hello', (req, res) => {
-  res.send({ hello: 'world' })
+  res.json({ hello: 'world' })
 })
 
 app.use('/greet', router)

--- a/benchmarks/express-with-middlewares.js
+++ b/benchmarks/express-with-middlewares.js
@@ -3,6 +3,9 @@
 var express = require('express')
 var app = express()
 
+app.disable('etag')
+app.disable('x-powered-by')
+
 app.use(require('cors')())
 app.use(require('dns-prefetch-control')())
 app.use(require('frameguard')())
@@ -12,7 +15,7 @@ app.use(require('ienoopen')())
 app.use(require('x-xss-protection')())
 
 app.get('/', function (req, res) {
-  res.send({ hello: 'world' })
+  res.json({ hello: 'world' })
 })
 
 app.listen(3000)

--- a/benchmarks/express.js
+++ b/benchmarks/express.js
@@ -3,8 +3,11 @@
 var express = require('express')
 var app = express()
 
+app.disable('etag')
+app.disable('x-powered-by')
+
 app.get('/', function (req, res) {
-  res.send({ hello: 'world' })
+  res.json({ hello: 'world' })
 })
 
 app.listen(3000)

--- a/benchmarks/hapi.js
+++ b/benchmarks/hapi.js
@@ -3,7 +3,11 @@
 const Hapi = require('hapi')
 
 // Create a server with a host and port
-const server = new Hapi.Server()
+const server = new Hapi.Server({
+  connections: {
+    compression: false
+  }
+})
 server.connection({
   host: 'localhost',
   port: 3000
@@ -13,6 +17,12 @@ server.connection({
 server.route({
   method: 'GET',
   path: '/',
+  config: {
+    cache: false,
+    response: {
+      ranges: false
+    }
+  },
   handler: function (request, reply) {
     return reply({ hello: 'world' })
   }

--- a/benchmarks/koa-router.js
+++ b/benchmarks/koa-router.js
@@ -5,7 +5,7 @@ var router = require('koa-router')()
 var app = new Koa()
 
 router.get('/', async (ctx) => {
-  ctx.body = JSON.stringify({ hello: 'world' })
+  ctx.body = { hello: 'world' }
 })
 
 app

--- a/benchmarks/koa.js
+++ b/benchmarks/koa.js
@@ -4,7 +4,7 @@ var Koa = require('koa')
 var app = new Koa()
 
 app.use(async (ctx) => {
-  ctx.body = JSON.stringify({ hello: 'world' })
+  ctx.body = { hello: 'world' }
 })
 
 app.listen(3000)

--- a/benchmarks/restify.js
+++ b/benchmarks/restify.js
@@ -1,5 +1,5 @@
 const restify = require('restify')
-const server = restify.createServer()
+const server = restify.createServer({ name: '' })
 server.get('/', (req, res) => {
   res.send({hello: 'world'})
 })


### PR DESCRIPTION
This updates the various example such that the HTTP response from each server is as close as possible to each other. The target response is to be the same as the Fastify response of
```
$ curl -i http://127.0.0.1:3000/
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 17
Date: Sun, 10 Sep 2017 16:06:04 GMT
Connection: keep-alive

{"hello":"world"}
```

A couple frameworks will add `;charset=utf-8` to the content-type, which I just left like that. The Koa example wasn't even using the built-in JSON serialization of the framework and was sending with a content-type of text/plain, so this is fixed now. The only one I couldn't make the same was `take-five`, which provides no way to turn off the CORS feature, so there is still CORS response headers.

imo this is good enough to close #4 