### PR TITLE
Fix benchmark error on first install

### DIFF
--- a/lib/autocannon.js
+++ b/lib/autocannon.js
@@ -4,7 +4,9 @@ const fs = require('fs')
 const globalModules = require('global-modules')
 const compare = require('autocannon-compare')
 
-module.exports.fire = (handler, save) => {
+const resultsDirectory = `${globalModules}/fastify-benchmarks/results`
+
+const run = async () => {
   return new Promise((resolve, reject) => {
     autocannon({
       url: 'http://localhost:3000',
@@ -17,21 +19,30 @@ module.exports.fire = (handler, save) => {
       if (err) {
         reject(err)
       } else {
-        if (save) {
-          // fs.writeFileSync(`./results/${handler}.json`, JSON.stringify(result))
-        }
-        fs.writeFileSync(`${globalModules}/fastify-benchmarks/results/${handler}.json`, JSON.stringify(result))
-        resolve(true)
+        resolve(result)
       }
     }
   })
 }
 
+const writeResult = async (handler, result) => {
+  if (!fs.existsSync(resultsDirectory)) {
+    fs.mkdirSync(resultsDirectory)
+  }
+
+  fs.writeFileSync(`${resultsDirectory}/${handler}.json`, JSON.stringify(result))
+
+  return true
+}
+
+module.exports.fire = async (handler, save) => {
+  const result = await run()
+  return await writeResult(handler, result)
+}
+
 module.exports.compare = (a, b) => {
-  const resA = require(`${globalModules}/fastify-benchmarks/results/${a}.json`)
-  // const resA = require(`../results/${a}.json`)
-  const resB = require(`${globalModules}/fastify-benchmarks/results/${b}.json`)
-  // const resB = require(`../results/${b}.json`)
+  const resA = require(`${resultsDirectory}/${a}.json`)
+  const resB = require(`${resultsDirectory}/${b}.json`)
 
   return compare(resA, resB)
 }


### PR DESCRIPTION
Sorry I didn't notice this issue with the previous PR #13 -- the `results` dir won't exist from a clean install, so it needs to be created if not already there.