### PR TITLE
Show percentage difference in compare text

### DIFF
--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -40,12 +40,10 @@ if (choices.length === 0) {
     }]).then(function (secondChoice) {
       let [a, b] = [firstChoice.choice, secondChoice.choice]
       let result = compare(a, b)
-      if (result.equal) {
+      if (result === true) {
         console.log(chalk.green.bold(`${a} and ${b} both are fast!`))
-      } else if (result.aWins) {
-        console.log(chalk.blue(`Both are awesome but`), chalk.green.bold(a), chalk.underline.blue(`is faster than`), chalk.bold.yellow(b))
       } else {
-        console.log(chalk.blue(`Both are awesome but`), chalk.bold.green(b), chalk.underline.blue(`is faster than`), chalk.bold.yellow(a))
+        console.log(chalk.blue(`Both are awesome but`), chalk.bold.green(result.fastest), chalk.blue(`is`), chalk.red(result.diff), chalk.blue(`faster than`), chalk.bold.yellow(result.slowest))
       }
     })
   })

--- a/lib/autocannon.js
+++ b/lib/autocannon.js
@@ -43,6 +43,21 @@ module.exports.fire = async (handler, save) => {
 module.exports.compare = (a, b) => {
   const resA = require(`${resultsDirectory}/${a}.json`)
   const resB = require(`${resultsDirectory}/${b}.json`)
+  const comp = compare(resA, resB)
 
-  return compare(resA, resB)
+  if (comp.equal) {
+    return true
+  } else if (comp.aWins) {
+    return {
+      diff: comp.requests.difference,
+      fastest: a,
+      slowest: b
+    }
+  } else {
+    return {
+      diff: compare(resB, resA).requests.difference,
+      fastest: b,
+      slowest: a
+    }
+  }
 }


### PR DESCRIPTION
I thought this could be cool with the existing compare command: to show the % diff that the autocannon-compare provides. I just added it to the existing faster than text. Looks like this:
```
$ benchmark compare
? What's your first pick? hapi
? What's your second one? fastify
Both are awesome but fastify is 505.63% faster than hapi
```